### PR TITLE
Adding the logged Exception-object as ExtendedProperty

### DIFF
--- a/Composite/Core/Logging/LoggingService.cs
+++ b/Composite/Core/Logging/LoggingService.cs
@@ -10,17 +10,14 @@ using Composite.Core.IO;
 using Microsoft.Practices.EnterpriseLibrary.Logging;
 using Microsoft.Practices.EnterpriseLibrary.Logging.Configuration;
 
-
 namespace Composite.Core.Logging
 {
-    /// <summary>    
-    /// </summary>
     /// <exclude />
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public static class LoggingService
     {
         /// <exclude />
-        [FlagsAttribute()]
+        [Flags]
         public enum Category
         {
             /// <exclude />
@@ -58,8 +55,7 @@ namespace Composite.Core.Logging
             LogEntry(title, message, null, category, severity, priority, eventid);
         }
 
-        /// <exclude />
-        static public void LogEntry(string title, string message, Exception exc, Category category, System.Diagnostics.TraceEventType severity, int priority, int eventid)
+        static private void LogEntry(string title, string message, Exception exc, Category category, System.Diagnostics.TraceEventType severity, int priority, int eventid)
         {
             var entry = new Microsoft.Practices.EnterpriseLibrary.Logging.LogEntry();
 


### PR DESCRIPTION
This Pull Request adds the logged Exception as a Extended Property to the LogEntry object written to the Logging Framework.

This enables custom Trace Listeners to later retrieve the Exception and use it like this

```
var entry = (LogEntry)data;
if (entry.ExtendedProperties.ContainsKey("Exception"))
{
   var exc = entry.ExtendedProperties["Exception"] as Exception;
   if (exc != null)
   {
      // Do something with exc
   }
}
```

Example of Code using this feature for correctly logging errors to Stackify https://github.com/burningice2866/CompositeC1Contrib/blob/master/Stackify/StackifyTraceListener.cs#L74