### PR TITLE
Marks the constructor of BaseValueProvider as public

### DIFF
--- a/Composite/Functions/BaseValueProvider.cs
+++ b/Composite/Functions/BaseValueProvider.cs
@@ -1,22 +1,20 @@
-using System;
 using System.Xml.Linq;
 using Composite.Core.Types;
 
-
 namespace Composite.Functions
 {
-    /// <summary>    
-    /// </summary>
     /// <exclude />
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
-	public abstract class BaseValueProvider
-	{
-        internal BaseValueProvider() { }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public abstract class BaseValueProvider
+    {
+        /// <exclude />
+        public BaseValueProvider() { }
 
         /// <exclude />
         public object GetValue()
         {
-            FunctionContextContainer internalContextContainer = new FunctionContextContainer();
+            var internalContextContainer = new FunctionContextContainer();
+
             return GetValue(internalContextContainer);
         }
 
@@ -40,5 +38,5 @@ namespace Composite.Functions
 
         /// <exclude />
         public abstract XObject Serialize();
-	}
+    }
 }


### PR DESCRIPTION
Marks the constructor of BaseValueProvider as public to make it possible for 3rd parties to create custom ValueProviders

Fixes https://github.com/Orckestra/CMS-Foundation/issues/254