### PR TITLE
Non-static WidgetFactoryMethod

### DIFF
--- a/Composite/AspNet/Razor/RazorFunction.cs
+++ b/Composite/AspNet/Razor/RazorFunction.cs
@@ -1,12 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using Composite.Core.Xml;
+using Composite.Functions;
+using Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvider;
 
 namespace Composite.AspNet.Razor
 {
     /// <summary>
     /// Base class for c1 functions based on razor 
     /// </summary>
-    public abstract class RazorFunction : CompositeC1WebPage
+    public abstract class RazorFunction : CompositeC1WebPage, IParameterWidgetsProvider
+
     {
         /// <summary>
         /// Gets the function description. Override this to make a custom description.
@@ -35,5 +39,12 @@ namespace Composite.AspNet.Razor
         {
             get { return typeof (XhtmlDocument); }
         }
+
+        /// <exclude />
+        public virtual IDictionary<string, WidgetFunctionProvider> GetParameterWidgets()
+        {
+            return null;
+        }
+
     }
 }

--- a/Composite/AspNet/UserControlFunction.cs
+++ b/Composite/AspNet/UserControlFunction.cs
@@ -1,12 +1,15 @@
-﻿using System.Web.UI;
+﻿using System.Collections.Generic;
+using System.Web.UI;
 using Composite.Functions;
+using Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvider;
 
 namespace Composite.AspNet
 {
     /// <summary>
     /// Base class for a UserControls that represents a C1 function
     /// </summary>
-    public abstract class UserControlFunction : UserControl
+    public abstract class UserControlFunction : UserControl, IParameterWidgetsProvider
+
     {
         /// <summary>
         /// Gets the function description.
@@ -24,5 +27,12 @@ namespace Composite.AspNet
             get; 
             set;
         }
+
+        /// <exclude />
+        public virtual IDictionary<string, WidgetFunctionProvider> GetParameterWidgets()
+        {
+            return null;
+        }
+
     }
 }

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -319,6 +319,7 @@
     <Compile Include="Plugins\Forms\WebChannel\UiControlFactories\TemplatedSvgIconSelectorUiControlFactory.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
+    <Compile Include="Plugins\Functions\FunctionProviders\FileBasedFunctionProvider\IParameterWidgetsProvider.cs" />
     <Compile Include="Plugins\Functions\WidgetFunctionProviders\StandardWidgetFunctionProvider\Utils\ConsoleIconSelectorWidgetFuntion.cs" />
     <Compile Include="Plugins\Functions\WidgetFunctionProviders\StandardWidgetFunctionProvider\Utils\SvgIconSelectorWidgetFuntion.cs" />
     <Compile Include="Plugins\Logging\LogTraceListeners\FileLogTraceListener\CircullarList.cs" />

--- a/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
@@ -45,6 +45,7 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
         public static IDictionary<string, FunctionParameter> GetParameters(object functionObject, Type baseFunctionType, string filePath)
         {
             var dict = new Dictionary<string, FunctionParameter>();
+            IDictionary<string, WidgetFunctionProvider> parameterWidgets = null;
 
             var type = functionObject.GetType();
             while (type != baseFunctionType && type != null)
@@ -92,6 +93,28 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
                             Log.LogWarning(LogTitle, ex);
                         }
                     }
+                    else
+                    {
+                        if (parameterWidgets == null)
+                        {
+                            var widgetsProvider = functionObject as IParameterWidgetsProvider;
+                            if (widgetsProvider != null)
+                            {
+                                parameterWidgets = widgetsProvider.GetParameterWidgets();
+                            }
+
+                            if (parameterWidgets == null)
+                            {
+                                parameterWidgets = new Dictionary<string, WidgetFunctionProvider>();
+                            }
+                        }
+
+                        if (parameterWidgets.ContainsKey(name))
+                        {
+                            widgetProvider = parameterWidgets[name];
+                        }
+                    }
+
 
                     if (!dict.ContainsKey(name))
                     {

--- a/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/IParameterWidgetsProvider.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/IParameterWidgetsProvider.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Composite.Functions;
+
+namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvider
+{
+    /// <exclude />
+    public interface IParameterWidgetsProvider
+    {
+        /// <exclude />
+        IDictionary<string, WidgetFunctionProvider> GetParameterWidgets();
+    }
+}


### PR DESCRIPTION
Supports defining widgets for function parameters using a non-static virtual method. This implementes feature request https://github.com/Orckestra/CMS-Foundation/issues/314

Usage:

```
public override IDictionary<string, WidgetFunctionProvider> GetParameterWidgets()
{
    return new Dictionary<string, WidgetFunctionProvider>
    {
        { nameof(Article), StandardWidgetFunctions.TextAreaWidget }
    };
}
```