### PR TITLE
Feature widgetfactorymethod (Razor and User Control Functions)

### DIFF
--- a/Composite/AspNet/Razor/RazorFunction.cs
+++ b/Composite/AspNet/Razor/RazorFunction.cs
@@ -1,12 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using Composite.Core.Xml;
+using Composite.Functions;
+using Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvider;
 
 namespace Composite.AspNet.Razor
 {
     /// <summary>
     /// Base class for c1 functions based on razor 
     /// </summary>
-    public abstract class RazorFunction : CompositeC1WebPage
+    public abstract class RazorFunction : CompositeC1WebPage, IParameterWidgetsProvider
+
     {
         /// <summary>
         /// Gets the function description. Override this to make a custom description.
@@ -35,5 +39,12 @@ namespace Composite.AspNet.Razor
         {
             get { return typeof (XhtmlDocument); }
         }
+
+        /// <exclude />
+        public virtual IDictionary<string, WidgetFunctionProvider> GetParameterWidgets()
+        {
+            return null;
+        }
+
     }
 }

--- a/Composite/AspNet/UserControlFunction.cs
+++ b/Composite/AspNet/UserControlFunction.cs
@@ -1,12 +1,15 @@
-﻿using System.Web.UI;
+﻿using System.Collections.Generic;
+using System.Web.UI;
 using Composite.Functions;
+using Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvider;
 
 namespace Composite.AspNet
 {
     /// <summary>
     /// Base class for a UserControls that represents a C1 function
     /// </summary>
-    public abstract class UserControlFunction : UserControl
+    public abstract class UserControlFunction : UserControl, IParameterWidgetsProvider
+
     {
         /// <summary>
         /// Gets the function description.
@@ -24,5 +27,12 @@ namespace Composite.AspNet
             get; 
             set;
         }
+
+        /// <exclude />
+        public virtual IDictionary<string, WidgetFunctionProvider> GetParameterWidgets()
+        {
+            return null;
+        }
+
     }
 }

--- a/Composite/Composite.csproj
+++ b/Composite/Composite.csproj
@@ -318,6 +318,7 @@
     <Compile Include="Plugins\Forms\WebChannel\UiControlFactories\TemplatedSvgIconSelectorUiControlFactory.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
+    <Compile Include="Plugins\Functions\FunctionProviders\FileBasedFunctionProvider\IParameterWidgetsProvider.cs" />
     <Compile Include="Plugins\Functions\WidgetFunctionProviders\StandardWidgetFunctionProvider\Utils\ConsoleIconSelectorWidgetFuntion.cs" />
     <Compile Include="Plugins\Functions\WidgetFunctionProviders\StandardWidgetFunctionProvider\Utils\SvgIconSelectorWidgetFuntion.cs" />
     <Compile Include="Plugins\Logging\LogTraceListeners\FileLogTraceListener\CircullarList.cs" />

--- a/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FileBasedFunction.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FileBasedFunction.cs
@@ -58,7 +58,7 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
 			    foreach (var param in Parameters.Values)
 			    {
 			        BaseValueProvider defaultValueProvider = new NoValueValueProvider();
-			        WidgetFunctionProvider widgetProvider = null;
+			        WidgetFunctionProvider widgetProvider = param.WidgetProvider;
 			        string label = param.Name;
 			        bool isRequired = true;
 			        string helpText = String.Empty;
@@ -81,8 +81,6 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
 			            {
 			                defaultValueProvider = new ConstantValueProvider(param.Attribute.DefaultValue);
 			            }
-
-			            widgetProvider = param.WidgetProvider;
 
 			            hideInSimpleView = param.Attribute.HideInSimpleView;
 			        }

--- a/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
@@ -45,7 +45,8 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
         public static IDictionary<string, FunctionParameter> GetParameters(object functionObject, Type baseFunctionType, string filePath)
         {
             var dict = new Dictionary<string, FunctionParameter>();
-            IDictionary<string, WidgetFunctionProvider> parameterWidgets = null;
+
+            IDictionary<string, WidgetFunctionProvider> parameterWidgets = GetParameterWidgets(functionObject);
 
             var type = functionObject.GetType();
             while (type != baseFunctionType && type != null)
@@ -95,20 +96,6 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
                     }
                     else
                     {
-                        if (parameterWidgets == null)
-                        {
-                            var widgetsProvider = functionObject as IParameterWidgetsProvider;
-                            if (widgetsProvider != null)
-                            {
-                                parameterWidgets = widgetsProvider.GetParameterWidgets();
-                            }
-
-                            if (parameterWidgets == null)
-                            {
-                                parameterWidgets = new Dictionary<string, WidgetFunctionProvider>();
-                            }
-                        }
-
                         if (parameterWidgets.ContainsKey(name))
                         {
                             widgetProvider = parameterWidgets[name];
@@ -126,6 +113,14 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
             }
 
             return dict;
+        }
+
+        private static IDictionary<string, WidgetFunctionProvider> GetParameterWidgets(object functionObject)
+        {
+            var widgetsProvider = functionObject as IParameterWidgetsProvider;
+            IDictionary<string, WidgetFunctionProvider> parameterWidgets = widgetsProvider != null ? widgetsProvider.GetParameterWidgets() : null;
+
+            return parameterWidgets ?? new Dictionary<string, WidgetFunctionProvider>();
         }
     }
 }

--- a/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
@@ -45,6 +45,7 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
         public static IDictionary<string, FunctionParameter> GetParameters(object functionObject, Type baseFunctionType, string filePath)
         {
             var dict = new Dictionary<string, FunctionParameter>();
+            IDictionary<string, WidgetFunctionProvider> parameterWidgets = null;
 
             var type = functionObject.GetType();
             while (type != baseFunctionType && type != null)
@@ -92,6 +93,28 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
                             Log.LogWarning(LogTitle, ex);
                         }
                     }
+                    else
+                    {
+                        if (parameterWidgets == null)
+                        {
+                            var widgetsProvider = functionObject as IParameterWidgetsProvider;
+                            if (widgetsProvider != null)
+                            {
+                                parameterWidgets = widgetsProvider.GetParameterWidgets();
+                            }
+
+                            if (parameterWidgets == null)
+                            {
+                                parameterWidgets = new Dictionary<string, WidgetFunctionProvider>();
+                            }
+                        }
+
+                        if (parameterWidgets.ContainsKey(name))
+                        {
+                            widgetProvider = parameterWidgets[name];
+                        }
+                    }
+
 
                     if (!dict.ContainsKey(name))
                     {

--- a/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
@@ -44,7 +44,7 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
         /// <returns></returns>
         public static IDictionary<string, FunctionParameter> GetParameters(object functionObject, Type baseFunctionType, string filePath)
         {
-            var dict = new Dictionary<string, FunctionParameter>();
+            var functionParameters = new Dictionary<string, FunctionParameter>();
             IDictionary<string, WidgetFunctionProvider> parameterWidgets = GetParameterWidgets(functionObject);
 
             var type = functionObject.GetType();
@@ -102,16 +102,16 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
                     }
 
 
-                    if (!dict.ContainsKey(name))
+                    if (!functionParameters.ContainsKey(name))
                     {
-                        dict.Add(name, new FunctionParameter(name, propType, attr, widgetProvider));
+                        functionParameters.Add(name, new FunctionParameter(name, propType, attr, widgetProvider));
                     }
                 }
 
                 type = type.BaseType;
             }
 
-            return dict;
+            return functionParameters;
         }
 
         private static IDictionary<string, WidgetFunctionProvider> GetParameterWidgets(object functionObject)

--- a/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/FunctionBasedFunctionProviderHelper.cs
@@ -13,7 +13,7 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
     /// </summary>
     public static class FunctionBasedFunctionProviderHelper
     {
-        private static readonly string LogTitle = typeof (FunctionBasedFunctionProviderHelper).FullName;
+        private static readonly string LogTitle = typeof(FunctionBasedFunctionProviderHelper).FullName;
 
         /// <summary>
         /// Gets the function description from the <see cref="FunctionAttribute" />.
@@ -45,7 +45,6 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
         public static IDictionary<string, FunctionParameter> GetParameters(object functionObject, Type baseFunctionType, string filePath)
         {
             var dict = new Dictionary<string, FunctionParameter>();
-
             IDictionary<string, WidgetFunctionProvider> parameterWidgets = GetParameterWidgets(functionObject);
 
             var type = functionObject.GetType();
@@ -69,7 +68,7 @@ namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvide
                     var attributes = property.GetCustomAttributes(typeof(FunctionParameterAttribute), false).Cast<FunctionParameterAttribute>().ToList();
 
 
-                    if(attributes.Count > 1)
+                    if (attributes.Count > 1)
                     {
                         Log.LogWarning(LogTitle, "More than one '{0}' attribute defined on property '{1}'. Location: '{2}'"
                                                  .FormatWith(typeof(FunctionParameterAttribute).Name, name, filePath));

--- a/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/IParameterWidgetsProvider.cs
+++ b/Composite/Plugins/Functions/FunctionProviders/FileBasedFunctionProvider/IParameterWidgetsProvider.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Composite.Functions;
+
+namespace Composite.Plugins.Functions.FunctionProviders.FileBasedFunctionProvider
+{
+    /// <exclude />
+    public interface IParameterWidgetsProvider
+    {
+        /// <exclude />
+        IDictionary<string, WidgetFunctionProvider> GetParameterWidgets();
+    }
+}


### PR DESCRIPTION
Pull request via 57a25aa - enabling defining parameter widgets via a method in addition to the existing Attribute based way.

Usage:

public override IDictionary<string, WidgetFunctionProvider> GetParameterWidgets()
{
    return new Dictionary<string, WidgetFunctionProvider>
    {
        { nameof(Article), StandardWidgetFunctions.TextAreaWidget }
    };
}